### PR TITLE
added webhooks module for the verify webhooks method. Fixed bugs in chec...

### DIFF
--- a/dwolla/checkouts.py
+++ b/dwolla/checkouts.py
@@ -48,10 +48,10 @@ def create(purchaseorder, params=False):
     if params:
         p = dict(p.items() + params.items())
 
-    id = r._post('/offsitegateway/checkouts/', p)
+    id = r._post('/offsitegateway/checkouts', p)
 
-    if 'CheckoutId' in id['Response']:
-        return dict({'URL': ((c.sandbox_host if c.sandbox else c.production_host) + 'payment/checkout/' + id['Response']['CheckoutId'])}.items() + id['Response'].items())
+    if 'CheckoutId' in id:
+        return dict({'URL': ((c.sandbox_host if c.sandbox else c.production_host) + 'payment/checkout/' + id['CheckoutId'])}.items() + id.items())
     else:
         raise Exception('Unable to create checkout due to API error.')
 

--- a/dwolla/webhooks.py
+++ b/dwolla/webhooks.py
@@ -1,0 +1,32 @@
+'''
+      _               _ _
+   __| |_      _____ | | | __ _
+  / _` \ \ /\ / / _ \| | |/ _` |
+ | (_| |\ V  V / (_) | | | (_| |
+  \__,_| \_/\_/ \___/|_|_|\__,_|
+
+  An official requests based wrapper for the Dwolla API.
+
+  This file contains functionality for all webhooks related endpoints.
+  ---------------------------------------------------------------------
+  These methods only submit requests to the API, the developer is
+  responsible for submitting properly formatted and correct requests.
+
+  Further information is available on: https://docs.dwolla.com
+'''
+import constants as c
+
+def verify(sig, body):
+  """
+    Verifies webhook signature hash against
+    server-provided hash.
+
+    :param sig: String with server provided signature.
+    :param body: request body.
+    :return:
+  """
+  import hmac
+  import hashlib
+
+  return hmac.new(c.client_secret, body, hashlib.sha1).hexdigest() == sig
+

--- a/tests/testCheckouts.py
+++ b/tests/testCheckouts.py
@@ -8,7 +8,7 @@ class CheckoutsTest(unittest.TestCase):
         checkouts.r._get = MagicMock()
         checkouts.r._post = MagicMock()
 
-        checkouts.r._post.return_value = dict({'Response': {'CheckoutId': 'TEST'}})
+        checkouts.r._post.return_value = dict({'CheckoutId': 'TEST'})
 
         constants.client_id = "SOME ID"
         constants.client_secret = "SOME ID"
@@ -32,7 +32,7 @@ class CheckoutsTest(unittest.TestCase):
                 'key1': 'something',
                 'key2': 'another thing'
             })})
-        checkouts.r._post.assert_any_call('/offsitegateway/checkouts/', {'client_secret': 'SOME ID', 'purchaseOrder': {'destinationId': '812-740-4294', 'total': 15.0, 'notes': 'blahhh', 'orderItems': set([frozenset(['price', 'description', 'name', 'quantity'])]), 'metadata': frozenset(['key2', 'key1'])}, 'client_id': 'SOME ID'})
+        checkouts.r._post.assert_any_call('/offsitegateway/checkouts', {'client_secret': 'SOME ID', 'purchaseOrder': {'destinationId': '812-740-4294', 'total': 15.0, 'notes': 'blahhh', 'orderItems': set([frozenset(['price', 'description', 'name', 'quantity'])]), 'metadata': frozenset(['key2', 'key1'])}, 'client_id': 'SOME ID'})
 
     def testget(self):
         checkouts.get('123456')


### PR DESCRIPTION
...kouts. The bug in checkouts is due to the fact that rest.py _post method has dwollaparse=True. This makes the response coming back already parsed. Also the I removed the last '/' from the endpoint because it was giving me problems.

When checkouts are complete. Usually you might wait for webhooks and thus need to verify them. I added a webhooks module with a verify method to handle this.