### PR TITLE
Incorrect parse instructions in oauth.refresh()

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository is for an old version of our API and is no longer actively maint
 
 ## Version
 
-2.3.1
+2.3.2
 
 [![Build Status](https://travis-ci.org/Dwolla/dwolla-python.svg?branch=master)](https://travis-ci.org/Dwolla/dwolla-python)
 

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ The new and improved Dwolla library based off of the Python ``requests`` client.
 Version
 -------
 
-2.3.1
+2.3.2
 
 Installation
 ------------
@@ -309,6 +309,8 @@ In order for the library's README file to display nicely on PyPi, we must use th
 
 Changelog
 ---------
+
+2.3.2 \* Fix bug json parsing bug in oauth.refresh() that prevented SDK from returning new tokens.
 
 2.3.1 \* Fix bug that prevented a code from being exchanged for a token.
 

--- a/dwolla/__init__.py
+++ b/dwolla/__init__.py
@@ -13,7 +13,7 @@
   Author -- Dwolla (David Stancu): api@dwolla.com, david@dwolla.com
   Copyright -- Copyright (C) 2014 Dwolla Inc.
   License -- MIT
-  Version -- 2.1.2
+  Version -- 2.3.2
   Link -- http://developers.dwolla.com
 '''
 

--- a/dwolla/oauth.py
+++ b/dwolla/oauth.py
@@ -90,6 +90,7 @@ def refresh(refreshtoken, **kwargs):
         'refresh_token': refreshtoken
     }
 
+    kwargs['dwollaparse'] = 'dict'
     return r._post_without_token('/token/', p, kwargs, custompostfix='/oauth/v2')
 
 def catalog(**kwargs):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='dwolla',
-    version='2.3.1',
+    version='2.3.2',
     packages=['dwolla'],
     install_requires=[
         'requests',


### PR DESCRIPTION
oauth.refresh() needs to send dwollaparse as dict so that _parse will treat it as dictionary instead of dwolla.  As is, it is failing because 'Success' is not a key in the return JSON from the refresh api call